### PR TITLE
Proper parallel steps

### DIFF
--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/core/HenshinConcurrentExecutionEngine.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/core/HenshinConcurrentExecutionEngine.xtend
@@ -36,6 +36,7 @@ import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.solvers.HenshinSolver
 /**
  * Henshin Concurrent Execution Engine implementation class that handles the main workflow
  */
+// FIXME: Is there value in implementing IConcurrentExecutionEngine?
 class HenshinConcurrentExecutionEngine extends AbstractExecutionEngine<IConcurrentExecutionContext, IConcurrentRunConfiguration> implements IConcurrentExecutionEngine {
 
 	val Engine henshinEngine = new EngineImpl
@@ -196,7 +197,7 @@ class HenshinConcurrentExecutionEngine extends AbstractExecutionEngine<IConcurre
 	 * set the selected Henshin Step
 	 * @param henshin step
 	 */
-	def setSelectedLogicalHenshinStep(Step step) {
+	def setSelectedLogicalHenshinStep(Step<?> step) {
 		synchronized (this) {
 			_selectedLogicalStep = step
 		}
@@ -238,50 +239,6 @@ class HenshinConcurrentExecutionEngine extends AbstractExecutionEngine<IConcurre
 			}
 		}
 	}
-
-	/**
-	 * notify the addons about the state of execution: about to execute step
-	 * the code is commented out due to the bug that was found
-	 * it should be uncommented after the fix is implemented by GEMOC
-	 * except for the modification, code taken from the concurrent ccsl engine
-	 */
-//	override notifyAboutToExecuteLogicalStep(Step<?> l) {
-//		for (IEngineAddon addon : getExecutionContext().getExecutionPlatform().getEngineAddons()) {
-//			try {
-//				// addon.aboutToExecuteStep(this, l);
-//			} catch (EngineStoppedException ese) {
-//				debug(
-//					"Addon (" + addon.getClass().getSimpleName() + "@" + addon.hashCode() +
-//						") has received stop command  with message : " + ese.getMessage());
-//				stop();
-//				throw ese;
-//			} catch (Exception e) {
-//				throw new RuntimeException(e);
-//			}
-//		}
-//	}
-
-	/**
-	 * notify the addons about the state of execution: step executed
-	 * code moved here from notifyAboutToExecuteLogicalStep
-	 * to be deleted when GEMOC implements a fix
-	 * except for the modification, code taken from the concurrent ccsl engine
-	 */
-//	override notifyLogicalStepExecuted(Step<?> l) {
-//		for (IEngineAddon addon : getExecutionContext().getExecutionPlatform().getEngineAddons()) {
-//			try {
-//				addon.aboutToExecuteStep(this, l);
-//				addon.stepExecuted(this, l);
-//			} catch (EngineStoppedException ese) {
-//				debug(
-//					"Addon (" + addon.getClass().getSimpleName() + "@" + addon.hashCode() +
-//						") has received stop command  with message : " + ese.getMessage());
-//				stop();
-//			} catch (Exception e) {
-//				throw new RuntimeException(e);
-//			}
-//		}
-//	}
 
 	override notifyProposedLogicalStepsChanged() {
 		throw new UnsupportedOperationException("TODO: auto-generated method stub")
@@ -345,14 +302,6 @@ class HenshinConcurrentExecutionEngine extends AbstractExecutionEngine<IConcurre
 				]
 				
 				afterExecutionStep()
-//				for (Step<?> step : getPossibleLogicalSteps()) {
-//					var s = step as HenshinStep
-//					if ((s.matches === null || s.matches.isEmpty) &&
-//						(selectedLogicalStep as HenshinStep).matches.contains(s.match)) {
-//						setSelectedLogicalHenshinStep(s)
-//						executeSelectedLogicalStep()
-//					}
-//				}
 			}
 
 		}

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/core/HenshinStep.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/core/HenshinStep.xtend
@@ -1,6 +1,5 @@
 package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.core
 
-import java.util.List
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.EcoreFactory
 import org.eclipse.emf.henshin.interpreter.Match
@@ -16,7 +15,7 @@ import org.eclipse.gemoc.trace.commons.model.trace.TracePackage
 class HenshinStep extends GenericSmallStepImpl {
 
 	protected Match match
-	protected List<Match> matches
+//	protected List<Match> matches
 
 	/**
 	 * create a new HenshinStep with a match
@@ -27,14 +26,14 @@ class HenshinStep extends GenericSmallStepImpl {
 		this.match = match
 	}
 
-	/**
-	 * create a new Henshin step with a sequence of rule matches
-	 * @param a list of matches
-	 */
-	new(List<Match> matches) {
-		super()
-		this.matches = matches
-	}
+//	/**
+//	 * create a new Henshin step with a sequence of rule matches
+//	 * @param a list of matches
+//	 */
+//	new(List<Match> matches) {
+//		super()
+//		this.matches = matches
+//	}
 
 	/**
 	 * return a MSEOccurence for a step, MSEOccurences represent objects that we run updates on 
@@ -45,12 +44,12 @@ class HenshinStep extends GenericSmallStepImpl {
 	 * mocked in this method to show a  more meaningful representation to the user.
 	 */
 	override getMseoccurrence() {
-		if (matches === null || matches.isEmpty) {
+//		if (matches === null || matches.isEmpty) {
 			generateMSE(match, match.getRule().getName(), match.toString())
-		} else {
-			val rulesNames = matches.map[m | m.rule.name].sort.join(' ')			
-			generateMSE(matches.get(0), rulesNames, rulesNames)
-		}
+//		} else {
+//			val rulesNames = matches.map[m | m.rule.name].sort.join(' ')			
+//			generateMSE(matches.get(0), rulesNames, rulesNames)
+//		}
 	}
 
 	/**

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/solvers/HenshinSolver.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/solvers/HenshinSolver.xtend
@@ -14,6 +14,7 @@ import org.eclipse.emf.henshin.model.ParameterKind
 import org.eclipse.emf.henshin.model.Rule
 import org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api.core.IConcurrentExecutionContext
 import org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api.moc.ISolver
+import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictraceFactory
 import org.eclipse.gemoc.trace.commons.model.trace.Step
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.core.HenshinStep
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.util.CPAHelper
@@ -79,8 +80,9 @@ class HenshinSolver implements ISolver {
 				var concatArr = new ArrayList<Match>();
 				concatArr.addAll(arr);
 				if (concatArr.length > 1) {
-					var step = new HenshinStep(concatArr);
-					possibleLogicalSteps.add(step)
+					val parStep = GenerictraceFactory.eINSTANCE.createGenericParallelStep
+					parStep.subSteps.addAll(concatArr.map[m | new HenshinStep(m)])
+					possibleLogicalSteps.add(parStep)
 				}
 			}
 	}


### PR DESCRIPTION
Creating and executing proper parallel steps rather than the slight `HenshinStep` fudge we currently use. 

Needs more work:

- [x] We had to remove a workaround for some odd behaviour of the Sirius animator. This needs fixing in GEMOC directly, see https://github.com/eclipse/gemoc-studio-modeldebugging/issues/96
- [ ] We need to do a proper code review of the execution engine and refactor it so that things happen in more logical places than where they currently are. We should also be able to get rid of many of the fields we're currently using, such as `_selectedStep`.
- [ ] We should investigate removing `HenshinStep` altogether, but this depends on having a more abstracted structure for `MSE`s and `MSEOccurrence`s. Probably needs to go into a separate issue / PR. See GEMOC issue here: https://github.com/eclipse/gemoc-studio-modeldebugging/issues/103