### PR TITLE
Upgrade CPA to the new Henshin 1.6 API

### DIFF
--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/META-INF/MANIFEST.MF
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/META-INF/MANIFEST.MF
@@ -43,10 +43,10 @@ Require-Bundle: fr.inria.diverse.k3.al.annotationprocessor.plugin;bundle-version
  org.eclipse.gemoc.execution.concurrent.ccsljavaengine.mse.model;bundle-version="2.3.0",
  org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3;bundle-version="2.3.0",
  org.eclipse.gemoc.executionframework.extensions.sirius;bundle-version="4.0.0",
- org.eclipse.emf.henshin.cpa.ui;bundle-version="1.4.0",
  fr.inria.aoste.trace;bundle-version="1.0.1",
- org.eclipse.emf.henshin.cpa;bundle-version="1.4.0",
- org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api;bundle-version="2.3.0"
+ org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api;bundle-version="2.3.0",
+ org.eclipse.emf.henshin.multicda.cpa;bundle-version="1.6.0",
+ org.eclipse.emf.henshin.multicda.cpa.ui;bundle-version="1.6.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin
 Bundle-ActivationPolicy: lazy

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/util/CPAHelper.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/util/CPAHelper.xtend
@@ -5,16 +5,16 @@ import java.util.HashMap
 import java.util.List
 import java.util.Map
 import java.util.Set
-import org.eclipse.emf.henshin.cpa.CPAOptions
-import org.eclipse.emf.henshin.cpa.CpaByAGG
-import org.eclipse.emf.henshin.cpa.result.CriticalElement
-import org.eclipse.emf.henshin.cpa.result.CriticalPair
 import org.eclipse.emf.henshin.interpreter.Match
 import org.eclipse.emf.henshin.model.Attribute
 import org.eclipse.emf.henshin.model.Edge
 import org.eclipse.emf.henshin.model.GraphElement
 import org.eclipse.emf.henshin.model.Node
 import org.eclipse.emf.henshin.model.Rule
+import org.eclipse.emf.henshin.multicda.cpa.CDAOptions
+import org.eclipse.emf.henshin.multicda.cpa.CpaByAGG
+import org.eclipse.emf.henshin.multicda.cpa.result.CriticalElement
+import org.eclipse.emf.henshin.multicda.cpa.result.CriticalPair
 import org.eclipse.xtend.lib.annotations.Data
 
 /**
@@ -32,9 +32,9 @@ class CPAHelper {
 	new(Set<Rule> rules) {
 		// Run Critical-Pair Analysis
 		val cpa = new CpaByAGG()
-		cpa.init(rules.toList, new CPAOptions())
+		cpa.init(rules, new CDAOptions())
 		var result = cpa.runConflictAnalysis()
-		// FIXME: With Henshin 1.5, can do: val criticalPairs = result.initialCriticalPairs
+		// TODO: We can now also say result.initialCriticalPairs, but somehow that then breaks our concurrency analysis.
 		val criticalPairs = result.criticalPairs
 
 		criticalPairs.forEach [ cp |


### PR DESCRIPTION
As above... the API for CDA has changed and needed an upgrade in our code.