### PR TITLE
Allow strategies to be changed during a debug session

### DIFF
--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/plugin.xml
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/plugin.xml
@@ -3,7 +3,7 @@
 <plugin>
 	<extension point="org.eclipse.debug.core.launchConfigurationTypes">
 		<launchConfigurationType
-			delegate="uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.launcher.HenshinConcurrentEngineLauncher"
+			delegate="uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.launcher.HenshinConcurrentEngineLauncher"
 			id="uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.launcher"
 			modes="run,debug"
 			name="Henshin-Based Concurrent eXecutable Model"
@@ -13,7 +13,7 @@
 	</extension>
 	<extension point="org.eclipse.debug.ui.launchConfigurationTabGroups">
 		<launchConfigurationTabGroup
-        class="uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.launcher.LauncherTabGroup"
+        class="uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.launcher.LauncherTabGroup"
         id="uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.launcher.tabGroup"
         type="uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.launcher">
 		</launchConfigurationTabGroup>

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/plugin.xml
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/plugin.xml
@@ -18,4 +18,14 @@
         type="uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.launcher">
 		</launchConfigurationTabGroup>
 	</extension>
+ <extension
+       point="org.eclipse.ui.views">
+    <view
+          category="org.eclipse.gemoc.executionframework.ui.category"
+          class="uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.strategy_selector.StrategySelectionView"
+          id="org.eclipse.gemoc.executionframework.engine.io.views.StrategySelectionView"
+          name="Strategy Selection"
+          restorable="true">
+    </view>
+ </extension>
 </plugin>

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/core/HenshinConcurrentExecutionEngine.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/core/HenshinConcurrentExecutionEngine.xtend
@@ -41,6 +41,8 @@ class HenshinConcurrentExecutionEngine extends AbstractConcurrentExecutionEngine
 	val RuleApplication ruleRunner = new RuleApplicationImpl(henshinEngine)
 	var EGraph modelGraph
 	var List<Rule> semanticRules
+	@Accessors(PUBLIC_GETTER)
+	var Module semantics
 	
 	// handling concurrent steps
 	var extension CPAHelper cpa
@@ -96,7 +98,7 @@ class HenshinConcurrentExecutionEngine extends AbstractConcurrentExecutionEngine
 
 		// Check validity
 		// Assume a direct link to a Henshin file
-		val semantics = semanticsResource.contents.head as Module
+		semantics = semanticsResource.contents.head as Module
 
 		if (!semantics.imports.contains(root.eClass.EPackage)) {
 			throw new IllegalArgumentException(

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/core/HenshinConcurrentRunConfiguration.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/core/HenshinConcurrentRunConfiguration.xtend
@@ -10,7 +10,7 @@ import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyReg
 
 class HenshinConcurrentRunConfiguration extends ConcurrentRunConfiguration {
 	
-	static val STRATEGIES_CONFIG_DATA_KEY = ".configData"
+	public static val STRATEGIES_CONFIG_DATA_KEY = ".configData"
 	
 	new(ILaunchConfiguration launchConfiguration) throws CoreException {
 		super(launchConfiguration)

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/AbstractStrategy.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/AbstractStrategy.xtend
@@ -1,0 +1,11 @@
+package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies
+
+abstract class AbstractStrategy implements Strategy {
+	val StrategyDefinition definition
+	
+	new(StrategyDefinition definition) {
+		this.definition = definition
+	}
+	
+	override StrategyDefinition getStrategyDefinition() { definition }
+}

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/Strategy.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/Strategy.xtend
@@ -1,5 +1,5 @@
 package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies
 
 interface Strategy {
-	
+	def StrategyDefinition getStrategyDefinition()
 }

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/StrategyControlUpdateListener.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/StrategyControlUpdateListener.xtend
@@ -1,0 +1,13 @@
+package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies
+
+/**
+ * Provides a way for changes in a StrategyDefinition-provided UI control to be communicated to the wider world, if there is interest.
+ */
+interface StrategyControlUpdateListener {
+	/**
+	 * Indicates that a user-initiated change (as opposed to a change as a result of an event from the LaunchConfigurationContext) 
+	 * has occurred to the control for the given strategy. It is the listener's responsibility to know how to deal with this and to 
+	 * find out the new state of the control.
+	 */
+	def void controlUpdated(StrategyDefinition sd)
+}

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/StrategyDefinition.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/StrategyDefinition.xtend
@@ -47,7 +47,7 @@ class StrategyDefinition {
 	/**
 	 * Provide an optional control to display in a launch tab to allow users to provide additional configuration information for the strategy. 
 	 */
-	def Control getUIControl(Composite parent, LaunchConfigurationContext lcc) { null }
+	def Control getUIControl(Composite parent, LaunchConfigurationContext lcc, StrategyControlUpdateListener scul) { null }
 
 	/**
 	 * Encode the user choice in a string that can be saved in a launch configuration.

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/StrategyDefinition.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/StrategyDefinition.xtend
@@ -32,7 +32,7 @@ class StrategyDefinition {
 	}
 
 	def instantiate() {
-		clazz.newInstance
+		clazz.getConstructor(StrategyDefinition).newInstance(this)
 	}
 
 	/**
@@ -58,5 +58,10 @@ class StrategyDefinition {
 	 * Initialise this strategy definition's control from the given configData
 	 */
 	def void initaliseControl(Control uiElement, String configData) {}
+
+	/**
+	 * Initialise this strategy definition's control from the given strategy
+	 */
+	def void initaliseControl(Control uiElement, Strategy strategy) {}
 
 }

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/concurrency/FullyOverlapStrategy.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/concurrency/FullyOverlapStrategy.xtend
@@ -1,9 +1,15 @@
 package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.concurrency
 
 import org.eclipse.emf.henshin.interpreter.Match
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.AbstractStrategy
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.ConcurrencyStrategy
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyDefinition
 
-class FullyOverlapStrategy implements ConcurrencyStrategy {
+class FullyOverlapStrategy extends AbstractStrategy implements ConcurrencyStrategy {
+	
+	new(StrategyDefinition definition) {
+		super(definition)
+	}
 	
 	override boolean canBeConcurrent (Match match1, Match match2){
 		val nodeTargets1 = match1.getNodeTargets();

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/concurrency/OverlapStrategy.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/concurrency/OverlapStrategy.xtend
@@ -1,9 +1,15 @@
 package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.concurrency
 
 import org.eclipse.emf.henshin.interpreter.Match
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.AbstractStrategy
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.ConcurrencyStrategy
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyDefinition
 
-class OverlapStrategy implements ConcurrencyStrategy {
+class OverlapStrategy extends AbstractStrategy implements ConcurrencyStrategy {
+	
+	new(StrategyDefinition definition) {
+		super(definition)
+	}
 	
 	// TODO: Should only check static parts
 	override boolean canBeConcurrent (Match match1, Match match2){

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/concurrency/SetOfRulesStrategy.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/concurrency/SetOfRulesStrategy.xtend
@@ -4,20 +4,22 @@ import java.util.List
 import org.eclipse.emf.henshin.interpreter.Match
 import org.eclipse.emf.henshin.model.Rule
 import org.eclipse.xtend.lib.annotations.Accessors
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.AbstractStrategy
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.ConcurrencyStrategy
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyDefinition
 
-class SetOfRulesStrategy implements ConcurrencyStrategy {
+class SetOfRulesStrategy extends AbstractStrategy implements ConcurrencyStrategy {
 
 	@Accessors
 	var List<Rule> rules
 
-	new(List<Rule> rules) {
-		super()
+	new(List<Rule> rules, StrategyDefinition definition) {
+		super(definition)
 		this.rules = rules;
 	}
 
-	new() {
-		this(emptyList)
+	new(StrategyDefinition definition) {
+		this(emptyList, definition)
 	}
 
 	override boolean canBeConcurrent(Match match1, Match match2) {

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/concurrency/SetOfRulesStrategyDefinition.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/concurrency/SetOfRulesStrategyDefinition.xtend
@@ -41,6 +41,15 @@ class SetOfRulesStrategyDefinition extends ConcurrencyStrategyDefinition {
 			list.select(#[0..list.itemCount-1].flatten.filter[namesToSelect.contains(list.items.get(it))])
 		}
 	}
+	
+	override void initaliseControl(Control uiElement, Strategy strategy) {
+		val list = uiElement as org.eclipse.swt.widgets.List
+		list.setSelection(#[] as int[])
+		
+		if (strategy instanceof SetOfRulesStrategy) {
+			list.selection = strategy.rules.map[name]
+		}
+	}
 
 	override initialise(Strategy strategy, String configData, LaunchConfigurationContext lcc) {
 		val h = strategy as SetOfRulesStrategy

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/concurrency/SetOfRulesStrategyDefinition.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/concurrency/SetOfRulesStrategyDefinition.xtend
@@ -8,13 +8,16 @@ import org.eclipse.swt.widgets.Composite
 import org.eclipse.swt.widgets.Control
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.LaunchConfigurationContext
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.Strategy
+import org.eclipse.swt.events.SelectionListener
+import org.eclipse.swt.events.SelectionEvent
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyControlUpdateListener
 
 class SetOfRulesStrategyDefinition extends ConcurrencyStrategyDefinition {
 	new() {
 		super("uk.ac.kcl.inf.xdsml.strategies.set_of_rules", "Set Of Rules Strategy", SetOfRulesStrategy)
 	}
-	
-	override getUIControl(Composite parent, LaunchConfigurationContext lcc) {
+
+	override getUIControl(Composite parent, LaunchConfigurationContext lcc, StrategyControlUpdateListener scul) {
 		val control = new org.eclipse.swt.widgets.List(parent, SWT.MULTI.bitwiseOr(SWT.V_SCROLL).bitwiseOr(SWT.BORDER))
 		control.layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false)
 
@@ -24,28 +27,39 @@ class SetOfRulesStrategyDefinition extends ConcurrencyStrategyDefinition {
 
 		control.updateSemantics(lcc.semantics)
 
+		if (scul !== null) {
+			control.addSelectionListener(new SelectionListener() {
+
+				override widgetDefaultSelected(SelectionEvent e) {}
+
+				override widgetSelected(SelectionEvent e) {
+					scul.controlUpdated(SetOfRulesStrategyDefinition.this)
+				}
+			})
+		}
+
 		control
 	}
 
 	override encodeConfigInformation(Control uiElement) {
 		val list = uiElement as org.eclipse.swt.widgets.List
 
-		list.selectionIndices.map[i | list.items.get(i)].join("@@")
+		list.selectionIndices.map[i|list.items.get(i)].join("@@")
 	}
 
 	override initaliseControl(Control uiElement, String configData) {
 		val list = uiElement as org.eclipse.swt.widgets.List
-		if (list.items.size > 0) {	
+		if (list.items.size > 0) {
 			val namesToSelect = configData.split("@@")
-	
-			list.select(#[0..list.itemCount-1].flatten.filter[namesToSelect.contains(list.items.get(it))])
+
+			list.select(#[0 .. list.itemCount - 1].flatten.filter[namesToSelect.contains(list.items.get(it))])
 		}
 	}
-	
+
 	override void initaliseControl(Control uiElement, Strategy strategy) {
 		val list = uiElement as org.eclipse.swt.widgets.List
 		list.setSelection(#[] as int[])
-		
+
 		if (strategy instanceof SetOfRulesStrategy) {
 			list.selection = strategy.rules.map[name]
 		}
@@ -57,7 +71,7 @@ class SetOfRulesStrategyDefinition extends ConcurrencyStrategyDefinition {
 		lcc.addSemanticsChangeListener([ evt |
 			h.updateSemantics(evt.newValue as List<Rule>, configData)
 		])
-		
+
 		h.updateSemantics(lcc.semantics, configData)
 	}
 
@@ -65,7 +79,7 @@ class SetOfRulesStrategyDefinition extends ConcurrencyStrategyDefinition {
 		control.items = emptyList
 
 		if (semantics !== null) {
-			semantics.forEach [r |
+			semantics.forEach [ r |
 				control.add(r.name)
 			]
 		}
@@ -73,10 +87,10 @@ class SetOfRulesStrategyDefinition extends ConcurrencyStrategyDefinition {
 
 	def updateSemantics(SetOfRulesStrategy sorh, List<Rule> semantics, String configData) {
 		sorh.rules.clear
-		
+
 		if (semantics !== null) {
 			val ruleNames = configData.split("@@").toList
-			sorh.rules = semantics.filter[r | ruleNames.contains(r.name)].toList			
+			sorh.rules = semantics.filter[r|ruleNames.contains(r.name)].toList
 		}
 	}
 }

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/filters/MaxNumberOfStepsStrategy.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/filters/MaxNumberOfStepsStrategy.xtend
@@ -8,20 +8,22 @@ import org.eclipse.gemoc.trace.commons.model.generictrace.GenerictraceFactory
 import org.eclipse.gemoc.trace.commons.model.trace.Step
 import org.eclipse.xtend.lib.annotations.Accessors
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.core.HenshinStep
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.AbstractStrategy
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.FilteringStrategy
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyDefinition
 
-class MaxNumberOfStepsStrategy implements FilteringStrategy {
+class MaxNumberOfStepsStrategy extends AbstractStrategy implements FilteringStrategy {
 
 	@Accessors
 	var int maxNumberOfSteps
 
-	new(int maxNumberOfSteps) {
-		super()
+	new(int maxNumberOfSteps, StrategyDefinition definition) {
+		super(definition)
 		this.maxNumberOfSteps = maxNumberOfSteps
 	}
 
-	new() {
-		this(2)
+	new(StrategyDefinition definition) {
+		this(2, definition)
 	}
 
 	override List<Step<?>> filter(List<Step<?>> steps) {

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/filters/MaxNumberOfStepsStrategyDefinition.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/filters/MaxNumberOfStepsStrategyDefinition.xtend
@@ -30,6 +30,15 @@ class MaxNumberOfStepsStrategyDefinition extends FilteringStrategyDefinition {
 		}
 	}
 
+	override void initaliseControl(Control uiElement, Strategy strategy) {
+		val txt = uiElement as Text
+		txt.text = ""
+		
+		if (strategy instanceof MaxNumberOfStepsStrategy) {
+			txt.text = strategy.maxNumberOfSteps.toString
+		}
+	}
+
 	override encodeConfigInformation(Control uiElement) {
 		val txt = uiElement as Text
 

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/filters/MaxNumberOfStepsStrategyDefinition.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/filters/MaxNumberOfStepsStrategyDefinition.xtend
@@ -7,15 +7,21 @@ import org.eclipse.swt.widgets.Control
 import org.eclipse.swt.widgets.Text
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.LaunchConfigurationContext
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.Strategy
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyControlUpdateListener
 
 class MaxNumberOfStepsStrategyDefinition extends FilteringStrategyDefinition {
 	new() {
 		super("uk.ac.kcl.inf.xdsml.strategies.num_steps", "Max Number of Steps Strategy", MaxNumberOfStepsStrategy)
 	}
 
-	override getUIControl(Composite parent, LaunchConfigurationContext lcc) {
+	override getUIControl(Composite parent, LaunchConfigurationContext lcc, StrategyControlUpdateListener scul) {
 		val control = new Text(parent, SWT.SINGLE.bitwiseOr(SWT.BORDER))
 		control.layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false)
+
+		if (scul !== null) {
+			control.addModifyListener[scul.controlUpdated(this)]
+		}
+
 		control
 	}
 
@@ -33,7 +39,7 @@ class MaxNumberOfStepsStrategyDefinition extends FilteringStrategyDefinition {
 	override void initaliseControl(Control uiElement, Strategy strategy) {
 		val txt = uiElement as Text
 		txt.text = ""
-		
+
 		if (strategy instanceof MaxNumberOfStepsStrategy) {
 			txt.text = strategy.maxNumberOfSteps.toString
 		}

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/filters/NonIdentityElementsStrategy.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/filters/NonIdentityElementsStrategy.xtend
@@ -8,7 +8,9 @@ import org.eclipse.gemoc.trace.commons.model.generictrace.GenericParallelStep
 import org.eclipse.gemoc.trace.commons.model.trace.Step
 import org.eclipse.xtend.lib.annotations.Accessors
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.core.HenshinStep
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.AbstractStrategy
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.FilteringStrategy
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyDefinition
 
 /**
  * Remove steps that differ only in objects of a specific type -- specify that objects of that type are not considered to have identity (e.g., parts in the PLS example).
@@ -17,7 +19,7 @@ import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.FilteringSt
  * of assemble (in the PLS case), for example. It's just not meaningful to have four ``different'' atomic assemble steps where there is only one machine. Hence, this is a filtering
  * strategy that needs to be applied after all possible concurrent executions have been computed.
  */
-class NonIdentityElementsStrategy implements FilteringStrategy {
+class NonIdentityElementsStrategy extends AbstractStrategy implements FilteringStrategy {
 
 	/**
 	 * Objects of these types should not be considered to have independent identity. So, while we can require to match multiple, distinct objects in one rule match, two rule matches 
@@ -26,11 +28,13 @@ class NonIdentityElementsStrategy implements FilteringStrategy {
 	@Accessors
 	var List<? extends EClass> nonIdentityTypes
 
-	new() {
+	new(StrategyDefinition definition) {
+		super(definition)
 		nonIdentityTypes = emptyList
 	}
 
-	new(List<? extends EClass> nonIdentityTypes) {
+	new(List<? extends EClass> nonIdentityTypes, StrategyDefinition definition) {
+		super(definition)
 		this.nonIdentityTypes = nonIdentityTypes
 	}
 

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/filters/NonIdentityElementsStrategyDefinition.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/filters/NonIdentityElementsStrategyDefinition.xtend
@@ -38,6 +38,15 @@ class NonIdentityElementsStrategyDefinition extends FilteringStrategyDefinition 
 		}
 	}
 
+	override void initaliseControl(Control uiElement, Strategy strategy) {
+		val list = uiElement as org.eclipse.swt.widgets.List
+		list.setSelection(#[] as int[])
+		
+		if (strategy instanceof NonIdentityElementsStrategy) {
+			list.selection = strategy.nonIdentityTypes.map[name]
+		}
+	}
+
 	override encodeConfigInformation(Control uiElement) {
 		val list = uiElement as org.eclipse.swt.widgets.List
 

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/filters/NonIdentityElementsStrategyDefinition.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/strategies/filters/NonIdentityElementsStrategyDefinition.xtend
@@ -9,6 +9,9 @@ import org.eclipse.swt.widgets.Composite
 import org.eclipse.swt.widgets.Control
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.LaunchConfigurationContext
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.Strategy
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyControlUpdateListener
+import org.eclipse.swt.events.SelectionListener
+import org.eclipse.swt.events.SelectionEvent
 
 class NonIdentityElementsStrategyDefinition extends FilteringStrategyDefinition {
 	new() {
@@ -16,7 +19,7 @@ class NonIdentityElementsStrategyDefinition extends FilteringStrategyDefinition 
 			NonIdentityElementsStrategy)
 	}
 
-	override getUIControl(Composite parent, LaunchConfigurationContext lcc) {
+	override getUIControl(Composite parent, LaunchConfigurationContext lcc, StrategyControlUpdateListener scul) {
 		val control = new org.eclipse.swt.widgets.List(parent, SWT.MULTI.bitwiseOr(SWT.V_SCROLL).bitwiseOr(SWT.BORDER))
 		control.layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false)
 
@@ -25,6 +28,17 @@ class NonIdentityElementsStrategyDefinition extends FilteringStrategyDefinition 
 		])
 
 		control.updateMetamodels(lcc.metamodels)
+		
+		if (scul !== null) {
+			control.addSelectionListener(new SelectionListener() {
+				
+				override widgetDefaultSelected(SelectionEvent e) { }
+				
+				override widgetSelected(SelectionEvent e) {
+					scul.controlUpdated(NonIdentityElementsStrategyDefinition.this)
+				}				
+			})
+		}
 
 		control
 	}

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/HenshinConcurrentEngineLauncher.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/HenshinConcurrentEngineLauncher.xtend
@@ -8,6 +8,7 @@ import org.eclipse.gemoc.xdsmlframework.api.core.ExecutionMode
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.core.HenshinConcurrentExecutionContext
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.core.HenshinConcurrentExecutionEngine
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.core.HenshinConcurrentRunConfiguration
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.strategy_selector.StrategySelectionView
 
 class HenshinConcurrentEngineLauncher extends AbstractConcurrentLauncher<HenshinConcurrentRunConfiguration, HenshinConcurrentExecutionContext> {
 
@@ -25,6 +26,6 @@ class HenshinConcurrentEngineLauncher extends AbstractConcurrentLauncher<Henshin
 	}
 
 	override protected getAdditionalViewsIDs() {
-		emptySet
+		#{StrategySelectionView.ID}
 	}
 }

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/HenshinConcurrentEngineLauncher.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/HenshinConcurrentEngineLauncher.xtend
@@ -1,4 +1,4 @@
-package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.launcher
+package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.launcher
 
 import org.eclipse.core.runtime.CoreException
 import org.eclipse.debug.core.ILaunchConfiguration

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/LauncherTabGroup.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/LauncherTabGroup.xtend
@@ -1,14 +1,14 @@
-package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.launcher
+package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.launcher
 
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup
 import org.eclipse.debug.ui.CommonTab
 import org.eclipse.debug.ui.ILaunchConfigurationDialog
-import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.launcher.tabs.LaunchConfigurationMainTab
-import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.launcher.tabs.LaunchConfigurationBackendsTab
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.launcher.tabs.LaunchConfigurationMainTab
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.launcher.tabs.LaunchConfigurationBackendsTab
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.LaunchConfigurationContext
 import java.beans.PropertyChangeListener
 import org.eclipse.emf.henshin.model.Rule
-import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.launcher.tabs.LaunchConfigurationStrategiesTab
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.launcher.tabs.LaunchConfigurationStrategiesTab
 
 /**
  * 

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationBackendsTab.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationBackendsTab.xtend
@@ -1,4 +1,4 @@
-package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.launcher.tabs
+package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.launcher.tabs
 
 import java.util.Collection
 import java.util.HashMap

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationDataProcessingTab.java
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationDataProcessingTab.java
@@ -1,4 +1,4 @@
-package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.launcher.tabs;
+package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.launcher.tabs;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationMainTab.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationMainTab.xtend
@@ -1,4 +1,4 @@
-package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.launcher.tabs
+package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.launcher.tabs
 
 import java.beans.PropertyChangeListener
 import java.beans.PropertyChangeSupport

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationStrategiesTab.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationStrategiesTab.xtend
@@ -1,4 +1,4 @@
-package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.launcher.tabs
+package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.launcher.tabs
 
 import java.util.Collections
 import java.util.HashMap

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationStrategiesTab.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationStrategiesTab.xtend
@@ -32,7 +32,7 @@ class LaunchConfigurationStrategiesTab extends LaunchConfigurationTab {
 	 */
 	new(LaunchConfigurationContext configContext) {
 		this.configContext = configContext
-		uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyRegistry.INSTANCE.strategies.forEach [ sd |
+		StrategyRegistry.INSTANCE.strategies.forEach [ sd |
 			strategySelections.put(sd, false)
 		]
 	}

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationStrategiesTab.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationStrategiesTab.xtend
@@ -71,7 +71,7 @@ class LaunchConfigurationStrategiesTab extends LaunchConfigurationTab {
 				override widgetDefaultSelected(SelectionEvent e) {}
 			})
 
-			components.put(hd, new Pair(checkbox, hd.getUIControl(parentGroup, configContext)))
+			components.put(hd, new Pair(checkbox, hd.getUIControl(parentGroup, configContext, null)))
 		]
 
 		// remove empty groups

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationStrategiesTab.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationStrategiesTab.xtend
@@ -1,131 +1,49 @@
 package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.launcher.tabs
 
 import java.util.Collections
-import java.util.HashMap
 import org.eclipse.debug.core.ILaunchConfiguration
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy
-import org.eclipse.swt.SWT
-import org.eclipse.swt.events.SelectionEvent
-import org.eclipse.swt.events.SelectionListener
-import org.eclipse.swt.layout.GridLayout
-import org.eclipse.swt.widgets.Button
 import org.eclipse.swt.widgets.Composite
 import org.eclipse.swt.widgets.Control
-import org.eclipse.swt.widgets.Group
-import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyDefinition.StrategyGroup
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.core.HenshinConcurrentRunConfiguration
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.LaunchConfigurationContext
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyDefinition
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyRegistry
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.strategy_selector.StrategyConfigurationUpdateListener
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.strategy_selector.StrategySelectionControl
 
 /**
- * 
  * Tab for choosing the step strategies.
- * 
  */
-class LaunchConfigurationStrategiesTab extends LaunchConfigurationTab {
-	val strategySelections = new HashMap<StrategyDefinition, Boolean>
-	val components = new HashMap<StrategyDefinition, Pair<Button, Control>>
+class LaunchConfigurationStrategiesTab extends LaunchConfigurationTab implements StrategyConfigurationUpdateListener {
 	val LaunchConfigurationContext configContext
+	var StrategySelectionControl strategyControl
 	
 	/**
 	 * Get all possible strategies and add them to the tab so the user can switch them on/off
 	 */
 	new(LaunchConfigurationContext configContext) {
 		this.configContext = configContext
-		StrategyRegistry.INSTANCE.strategies.forEach [ sd |
-			strategySelections.put(sd, false)
-		]
 	}
 
 	override createControl(Composite parent) {
-		val content = new Composite(parent, SWT.NULL)
-		val gl = new GridLayout(1, false)
-
-		gl.marginHeight = 0
-		content.setLayout(gl)
-		content.layout()
-		setControl(content)
-
-		createLayout(content)
+		strategyControl = new StrategySelectionControl(parent, configContext)
+		setControl(strategyControl)		
 	}
-
-	private def createLayout(Composite parent) {
-		val groupmap = new HashMap<StrategyGroup, Group>()
-		
-		groupmap.put(StrategyGroup.CONCURRENCY_STRATEGY, createGroup(parent, "Concurrency Strategies"))
-		groupmap.put(StrategyGroup.FILTERING_STRATEGY, createGroup(parent, "Filtering Strategies"))
-
-		strategySelections.keySet.forEach [ hd |
-
-			var parentGroup = groupmap.get(hd.group)
-
-			val checkbox = createCheckButton(parentGroup, hd.humanReadableLabel)
-			checkbox.selection = strategySelections.get(hd)
-			checkbox.addSelectionListener(new SelectionListener() {
-
-				override widgetSelected(SelectionEvent e) {
-					strategySelections.put(hd, checkbox.selection)
-					updateLaunchConfigurationDialog();
-				}
-
-				override widgetDefaultSelected(SelectionEvent e) {}
-			})
-
-			components.put(hd, new Pair(checkbox, hd.getUIControl(parentGroup, configContext, null)))
-		]
-
-		// remove empty groups
-		groupmap.values.forEach [ g |
-			if (g.children.length === 0) {
-				g.dispose()
-				parent.layout(true)
-			}
-		]
-	}
-
-	static val STRATEGIES_CONFIG_DATA_KEY = ".configData"
 
 	override setDefaults(ILaunchConfigurationWorkingCopy configuration) {
 		configuration.setAttribute(StrategyRegistry.STRATEGIES_CONFIG_KEY, Collections.EMPTY_LIST)
 		StrategyRegistry.INSTANCE.strategies.forEach [ hd |
-			configuration.removeAttribute(hd.strategyID + STRATEGIES_CONFIG_DATA_KEY)
+			configuration.removeAttribute(hd.strategyID + HenshinConcurrentRunConfiguration.STRATEGIES_CONFIG_DATA_KEY)
 		]
 	}
 
 	override initializeFrom(ILaunchConfiguration configuration) {
-
-		strategySelections.keySet.forEach[hd|strategySelections.put(hd, false)]
-
-		val strategies = configuration.getAttribute(StrategyRegistry.STRATEGIES_CONFIG_KEY, #[])
-		strategies.forEach [ sid |
-			strategySelections.put(StrategyRegistry.INSTANCE.get(sid), true)
-		]
-
-		strategySelections.forEach [ extension sd, selected |
-			val strategyComponents = components.get(sd)
-			val checkbox = strategyComponents.key
-			if (checkbox !== null) {
-				checkbox.selection = selected
-			}
-
-			val hComponent = strategyComponents.value
-			if (hComponent !== null) {
-				hComponent.initaliseControl(configuration.getAttribute(sd.strategyID + STRATEGIES_CONFIG_DATA_KEY, ""))
-			}
-		]
+		strategyControl.initialiseFrom(configuration)
 	}
 
 	override performApply(ILaunchConfigurationWorkingCopy configuration) {
-		val selectedStrategies = strategySelections.filter[hd, selected|selected].keySet
-		configuration.setAttribute(StrategyRegistry.STRATEGIES_CONFIG_KEY,
-			selectedStrategies.map[it.getStrategyID].toList)
-		selectedStrategies.forEach [ extension hd |
-			val strategyComponent = components.get(hd).value
-			if (strategyComponent !== null) {
-				configuration.setAttribute(hd.getStrategyID + STRATEGIES_CONFIG_DATA_KEY,
-					strategyComponent.encodeConfigInformation())
-			}
-		]
+		strategyControl.saveConfiguration(configuration)
 	}
 
 	override isValid(ILaunchConfiguration config) {
@@ -134,4 +52,8 @@ class LaunchConfigurationStrategiesTab extends LaunchConfigurationTab {
 	}
 
 	override getName() { "Steps Strategies" }
+	
+	override onStrategyConfigurationHasChanged(StrategyDefinition sd, boolean isSelected, Control uiControl) {
+		updateLaunchConfigurationDialog()
+	}
 }

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationTab.java
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/launcher/tabs/LaunchConfigurationTab.java
@@ -1,4 +1,4 @@
-package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.launcher.tabs;
+package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.launcher.tabs;
 
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTab;
 import org.eclipse.swt.SWT;

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/strategy_selector/StrategyConfigurationUpdateListener.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/strategy_selector/StrategyConfigurationUpdateListener.xtend
@@ -1,0 +1,18 @@
+package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.strategy_selector
+
+import org.eclipse.swt.widgets.Control
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyDefinition
+
+interface StrategyConfigurationUpdateListener {
+	/** 
+	 * Called whenever the user makes changes to the selection status or additional information of a strategy.
+	 * 
+	 * @param sd the strategy definiton for which the configuration information has been changed
+	 * @param isSelected true if the user has selected the strategy to be included
+	 * @param uiControl the control, if any, provided by the strategy definition for the user to make additional changes to 
+	 *                  the strategy configuration. The strategy definition knows how to use this to configure a given strategy.
+	 *                  May be <code>null</code>
+	 */
+	def void onStrategyConfigurationHasChanged(StrategyDefinition sd, boolean isSelected, Control uiControl)
+
+}

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/strategy_selector/StrategySelectionControl.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/strategy_selector/StrategySelectionControl.xtend
@@ -1,0 +1,158 @@
+package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.strategy_selector
+
+import java.util.HashMap
+import org.eclipse.debug.core.ILaunchConfiguration
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy
+import org.eclipse.debug.internal.ui.SWTFactory
+import org.eclipse.swt.SWT
+import org.eclipse.swt.events.SelectionEvent
+import org.eclipse.swt.events.SelectionListener
+import org.eclipse.swt.layout.GridLayout
+import org.eclipse.swt.widgets.Button
+import org.eclipse.swt.widgets.Composite
+import org.eclipse.swt.widgets.Control
+import org.eclipse.swt.widgets.Group
+import org.eclipse.xtend.lib.annotations.Accessors
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure2
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.core.HenshinConcurrentExecutionEngine
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.core.HenshinConcurrentRunConfiguration
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.LaunchConfigurationContext
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyDefinition
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyDefinition.StrategyGroup
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyRegistry
+
+/**
+ * Control for selecting and configuring strategies.
+ */
+class StrategySelectionControl extends Composite {
+
+	val strategySelections = new HashMap<StrategyDefinition, Boolean>
+	val components = new HashMap<StrategyDefinition, Pair<Button, Control>>
+	val LaunchConfigurationContext configContext
+	
+	@Accessors(PUBLIC_SETTER)
+	var StrategyConfigurationUpdateListener updateListener = null
+
+	new(Composite parent, LaunchConfigurationContext configContext) {
+		super(parent, SWT.NULL)
+
+		this.configContext = configContext
+
+		StrategyRegistry.INSTANCE.strategies.forEach [ sd |
+			strategySelections.put(sd, false)
+		]
+
+		val gl = new GridLayout(1, false)
+
+		gl.marginHeight = 0
+		setLayout(gl)
+		layout()
+
+		createLayout
+	}
+
+	def initialiseFrom(ILaunchConfiguration configuration) {
+		initialiseFrom(configuration.getAttribute(StrategyRegistry.STRATEGIES_CONFIG_KEY, #[]), 
+			[control, extension sd | control.initaliseControl(configuration.getAttribute(sd.strategyID + HenshinConcurrentRunConfiguration.STRATEGIES_CONFIG_DATA_KEY, ""))]
+		)
+	}
+
+	def updateSelectionsFrom(HenshinConcurrentExecutionEngine engine) {
+		val strategies = (engine.concurrencyStrategies + engine.filteringStrategies).groupBy[strategyDefinition]
+		initialiseFrom(strategies.keySet.map[strategyID], [control, extension sd | control.initaliseControl(strategies.get(sd)?.head)])		
+	}
+
+	def saveConfiguration(ILaunchConfigurationWorkingCopy configuration) {
+		val selectedStrategies = strategySelections.filter[hd, selected|selected].keySet
+		configuration.setAttribute(StrategyRegistry.STRATEGIES_CONFIG_KEY,
+			selectedStrategies.map[it.getStrategyID].toList)
+		selectedStrategies.forEach [ extension hd |
+			val strategyComponent = components.get(hd).value
+			if (strategyComponent !== null) {
+				configuration.setAttribute(hd.getStrategyID + HenshinConcurrentRunConfiguration.STRATEGIES_CONFIG_DATA_KEY,
+					strategyComponent.encodeConfigInformation())
+			}
+		]
+	}
+
+	private def createLayout() {
+		val groupmap = new HashMap<StrategyGroup, Group>()
+
+		groupmap.put(StrategyGroup.CONCURRENCY_STRATEGY, createGroup(this, "Concurrency Strategies"))
+		groupmap.put(StrategyGroup.FILTERING_STRATEGY, createGroup(this, "Filtering Strategies"))
+
+		strategySelections.keySet.forEach [ sd |
+
+			var parentGroup = groupmap.get(sd.group)
+
+			val checkbox = createCheckButton(parentGroup, sd.humanReadableLabel)
+			checkbox.selection = strategySelections.get(sd)
+
+			val uiControl = sd.getUIControl(parentGroup, configContext, [
+				val isSelected = strategySelections.get(sd)
+				
+				if (isSelected) {
+					// No point updating the detailed strategy config otherwise...
+					updateListener.onStrategyConfigurationHasChanged(sd, isSelected, components.get(sd).value)		
+				}
+			])
+			components.put(sd, new Pair(checkbox, uiControl))
+
+			checkbox.addSelectionListener(new SelectionListener() {
+
+				override widgetSelected(SelectionEvent e) {
+					strategySelections.put(sd, checkbox.selection)
+					updateListener.onStrategyConfigurationHasChanged(sd, checkbox.selection, uiControl)
+				}
+
+				override widgetDefaultSelected(SelectionEvent e) {}
+			})
+		]
+
+		// remove empty groups
+		groupmap.values.forEach [ g |
+			if (g.children.length === 0) {
+				g.dispose()
+				this.layout(true)
+			}
+		]
+	}
+
+	private def Group createGroup(Composite parent, String text) {
+		val group = new Group(parent, SWT.NULL)
+		group.setText(text)
+
+		val locationLayout = new GridLayout()
+		locationLayout.numColumns = 5
+		locationLayout.marginHeight = 10
+		locationLayout.marginWidth = 10
+		group.setLayout(locationLayout)
+
+		group
+	}
+
+	private def Button createCheckButton(Composite parent, String label) {
+		SWTFactory.createCheckButton(parent, label, null, false, 1)
+	}	
+
+	private def initialiseFrom(Iterable<String> selectedStrategiesIDs, Procedure2<Control, StrategyDefinition> initialiseControl) {
+		strategySelections.keySet.forEach[hd|strategySelections.put(hd, false)]
+
+		selectedStrategiesIDs.forEach [ sid |
+			strategySelections.put(StrategyRegistry.INSTANCE.get(sid), true)
+		]
+
+		strategySelections.forEach [ extension sd, selected |
+			val strategyComponents = components.get(sd)
+			val checkbox = strategyComponents.key
+			if (checkbox !== null) {
+				checkbox.selection = selected
+			}
+
+			val hComponent = strategyComponents.value
+			if (hComponent !== null) {
+				initialiseControl.apply(hComponent, sd)
+			}
+		]
+	}
+}

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/strategy_selector/StrategySelectionView.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/strategy_selector/StrategySelectionView.xtend
@@ -1,25 +1,107 @@
 package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.strategy_selector
 
+import java.util.HashMap
+import org.eclipse.debug.internal.ui.SWTFactory
 import org.eclipse.gemoc.executionframework.ui.views.engine.EngineSelectionDependentViewPart
-import org.eclipse.swt.widgets.Composite
 import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine
+import org.eclipse.swt.SWT
+import org.eclipse.swt.events.SelectionEvent
+import org.eclipse.swt.events.SelectionListener
+import org.eclipse.swt.layout.GridLayout
+import org.eclipse.swt.widgets.Button
+import org.eclipse.swt.widgets.Composite
+import org.eclipse.swt.widgets.Group
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyDefinition
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyDefinition.StrategyGroup
+import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyRegistry
 import org.eclipse.swt.layout.GridData
 import org.eclipse.swt.widgets.Label
-import org.eclipse.swt.SWT
 
 class StrategySelectionView extends EngineSelectionDependentViewPart {
 	
 	public static val ID = "org.eclipse.gemoc.executionframework.engine.io.views.StrategySelectionView"
-	
+
+	val strategySelections = new HashMap<StrategyDefinition, Boolean>	
+
+	new() {
+		StrategyRegistry.INSTANCE.strategies.forEach [ sd |
+			strategySelections.put(sd, false)
+		]
+	}
+
+	// TODO: This needs refactoring: currently copied across from LaunchConfigTab	
 	override createPartControl(Composite parent) {
-		val gd = new GridData(GridData.FILL_HORIZONTAL)
-		parent.setLayoutData(gd)
-		val inputLabel = new Label(parent, SWT.NONE)
-		inputLabel.setText("Test")
-		
-//		throw new UnsupportedOperationException("TODO: auto-generated method stub")
+		val content = new Composite(parent, SWT.NULL)
+		val gl = new GridLayout(1, false)
+
+		gl.marginHeight = 0
+		content.setLayout(gl)
+		content.layout()
+
+		createLayout(content)
 	}
 	
+	// TODO: This needs refactoring: currently copied across from LaunchConfigTab	
+	private def createLayout(Composite parent) {
+		createTextLabelLayout(parent, "Update strategy selection below. This will take effect from the next step.")
+		
+		val groupmap = new HashMap<StrategyGroup, Group>()
+		
+		groupmap.put(StrategyGroup.CONCURRENCY_STRATEGY, createGroup(parent, "Concurrency Strategies"))
+		groupmap.put(StrategyGroup.FILTERING_STRATEGY, createGroup(parent, "Filtering Strategies"))
+
+		strategySelections.keySet.forEach [ hd |
+
+			var parentGroup = groupmap.get(hd.group)
+
+			val checkbox = createCheckButton(parentGroup, hd.humanReadableLabel)
+			checkbox.selection = strategySelections.get(hd)
+			checkbox.addSelectionListener(new SelectionListener() {
+
+				override widgetSelected(SelectionEvent e) {
+					strategySelections.put(hd, checkbox.selection)
+//					updateLaunchConfigurationDialog();
+				}
+
+				override widgetDefaultSelected(SelectionEvent e) {}
+			})
+
+//			components.put(hd, new Pair(checkbox, hd.getUIControl(parentGroup, configContext)))
+		]
+
+		// remove empty groups
+		groupmap.values.forEach [ g |
+			if (g.children.length === 0) {
+				g.dispose()
+				parent.layout(true)
+			}
+		]
+	}
+	
+	protected def createTextLabelLayout(Composite parent, String labelString) {
+		val gd = new GridData(GridData.FILL_HORIZONTAL)
+		parent.setLayoutData(gd)
+		val label = new Label(parent, SWT.NONE)
+		label.setText(labelString)
+	}
+	
+	protected def Group createGroup(Composite parent, String text) {
+		val group = new Group(parent, SWT.NULL)
+		group.setText(text)
+		
+		val locationLayout = new GridLayout()
+		locationLayout.numColumns = 5
+		locationLayout.marginHeight = 10
+		locationLayout.marginWidth = 10
+		group.setLayout(locationLayout)
+		
+		group
+	}
+	
+	protected def Button createCheckButton(Composite parent, String label) {
+		SWTFactory.createCheckButton(parent, label, null, false, 1)
+	}
+
 	override setFocus() {
 //		throw new UnsupportedOperationException("TODO: auto-generated method stub")
 	}

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/strategy_selector/StrategySelectionView.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/strategy_selector/StrategySelectionView.xtend
@@ -2,23 +2,17 @@ package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.strategy_selector
 
 import java.beans.PropertyChangeListener
 import java.beans.PropertyChangeSupport
-import java.util.HashMap
 import java.util.List
-import org.eclipse.debug.internal.ui.SWTFactory
 import org.eclipse.emf.ecore.EPackage
 import org.eclipse.emf.henshin.model.Module
 import org.eclipse.emf.henshin.model.Rule
 import org.eclipse.gemoc.executionframework.ui.views.engine.EngineSelectionDependentViewPart
 import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine
 import org.eclipse.swt.SWT
-import org.eclipse.swt.events.SelectionEvent
-import org.eclipse.swt.events.SelectionListener
 import org.eclipse.swt.layout.GridData
 import org.eclipse.swt.layout.GridLayout
-import org.eclipse.swt.widgets.Button
 import org.eclipse.swt.widgets.Composite
 import org.eclipse.swt.widgets.Control
-import org.eclipse.swt.widgets.Group
 import org.eclipse.swt.widgets.Label
 import org.eclipse.xtend.lib.annotations.Accessors
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.core.HenshinConcurrentExecutionEngine
@@ -26,15 +20,12 @@ import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.Concurrency
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.FilteringStrategy
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.LaunchConfigurationContext
 import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyDefinition
-import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyDefinition.StrategyGroup
-import uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.strategies.StrategyRegistry
 
-class StrategySelectionView extends EngineSelectionDependentViewPart {
+class StrategySelectionView extends EngineSelectionDependentViewPart implements StrategyConfigurationUpdateListener {
 
 	public static val ID = "org.eclipse.gemoc.executionframework.engine.io.views.StrategySelectionView"
 
-	val strategySelections = new HashMap<StrategyDefinition, Boolean>
-	val components = new HashMap<StrategyDefinition, Pair<Button, Control>>
+	var StrategySelectionControl strategyControl
 
 	private static class EngineWrappingLaunchConfigurationContext implements LaunchConfigurationContext {
 		val pcs = new PropertyChangeSupport(this)
@@ -122,13 +113,6 @@ class StrategySelectionView extends EngineSelectionDependentViewPart {
 
 	val configContext = new EngineWrappingLaunchConfigurationContext
 
-	new() {
-		StrategyRegistry.INSTANCE.strategies.forEach [ sd |
-			strategySelections.put(sd, false)
-		]
-	}
-
-	// TODO: This needs refactoring: currently copied across from LaunchConfigTab	
 	override createPartControl(Composite parent) {
 		val content = new Composite(parent, SWT.NULL)
 		val gl = new GridLayout(1, false)
@@ -140,45 +124,11 @@ class StrategySelectionView extends EngineSelectionDependentViewPart {
 		createLayout(content)
 	}
 
-	// TODO: This needs refactoring: currently copied across from LaunchConfigTab	
 	private def createLayout(Composite parent) {
 		createTextLabelLayout(parent, "Update strategy selection below. This will take effect from the next step.")
-
-		val groupmap = new HashMap<StrategyGroup, Group>()
-
-		groupmap.put(StrategyGroup.CONCURRENCY_STRATEGY, createGroup(parent, "Concurrency Strategies"))
-		groupmap.put(StrategyGroup.FILTERING_STRATEGY, createGroup(parent, "Filtering Strategies"))
-
-		strategySelections.keySet.forEach [ sd |
-
-			var parentGroup = groupmap.get(sd.group)
-
-			val checkbox = createCheckButton(parentGroup, sd.humanReadableLabel)
-			checkbox.selection = strategySelections.get(sd)
-
-			val uiControl = sd.getUIControl(parentGroup, configContext, [
-				sd.updateEngineStrategyDetails()
-			])
-			components.put(sd, new Pair(checkbox, uiControl))
-
-			checkbox.addSelectionListener(new SelectionListener() {
-
-				override widgetSelected(SelectionEvent e) {
-					strategySelections.put(sd, checkbox.selection)
-					updateEngineStrategySelection(sd, checkbox.selection, uiControl)
-				}
-
-				override widgetDefaultSelected(SelectionEvent e) {}
-			})
-		]
-
-		// remove empty groups
-		groupmap.values.forEach [ g |
-			if (g.children.length === 0) {
-				g.dispose()
-				parent.layout(true)
-			}
-		]
+		
+		strategyControl = new StrategySelectionControl(parent, configContext)
+		strategyControl.updateListener = this
 	}
 
 	protected def createTextLabelLayout(Composite parent, String labelString) {
@@ -188,54 +138,16 @@ class StrategySelectionView extends EngineSelectionDependentViewPart {
 		label.setText(labelString)
 	}
 
-	protected def Group createGroup(Composite parent, String text) {
-		val group = new Group(parent, SWT.NULL)
-		group.setText(text)
-
-		val locationLayout = new GridLayout()
-		locationLayout.numColumns = 5
-		locationLayout.marginHeight = 10
-		locationLayout.marginWidth = 10
-		group.setLayout(locationLayout)
-
-		group
-	}
-
-	protected def Button createCheckButton(Composite parent, String label) {
-		SWTFactory.createCheckButton(parent, label, null, false, 1)
-	}
-
 	override setFocus() {}
 
 	override engineSelectionChanged(IExecutionEngine<?> engine) {
 		configContext.setEngine(engine) // need to explictly call setter because Xtend is stupid
 		if (engine instanceof HenshinConcurrentExecutionEngine) {
-			updateSelectionsFrom(engine)
+			strategyControl.updateSelectionsFrom(engine)
 		}
 	}
 
-	private def updateSelectionsFrom(HenshinConcurrentExecutionEngine engine) {
-		strategySelections.keySet.forEach[hd|strategySelections.put(hd, false)]
-
-		val strategies = (engine.concurrencyStrategies + engine.filteringStrategies).groupBy[strategyDefinition]
-		strategies.keySet.forEach[strategySelections.put(it, true)]
-
-		strategySelections.forEach [ extension sd, selected |
-			val strategyComponents = components.get(sd)
-			val checkbox = strategyComponents.key
-			if (checkbox !== null) {
-				checkbox.selection = selected
-			}
-
-			val hComponent = strategyComponents.value
-			if (hComponent !== null) {
-				hComponent.initaliseControl(strategies.get(sd)?.head)
-			}
-		]
-
-	}
-
-	protected def updateEngineStrategySelection(StrategyDefinition sd, boolean selected, Control control) {
+	override onStrategyConfigurationHasChanged(StrategyDefinition sd, boolean selected, Control control) {
 		if (configContext.engine !== null) {
 			if (configContext.engine instanceof HenshinConcurrentExecutionEngine) {
 				val engine = configContext.engine as HenshinConcurrentExecutionEngine
@@ -262,14 +174,5 @@ class StrategySelectionView extends EngineSelectionDependentViewPart {
 				}
 			}
 		}
-	}
-	
-	protected def updateEngineStrategyDetails(StrategyDefinition sd) {
-		val isSelected = strategySelections.get(sd)
-		
-		if (isSelected) {
-			// No point updating the detailed strategy config otherwise...
-			sd.updateEngineStrategySelection(isSelected, components.get(sd).value)		
-		}
-	}
+	}	
 }

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/strategy_selector/StrategySelectionView.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/strategy_selector/StrategySelectionView.xtend
@@ -3,19 +3,29 @@ package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.strategy_selector
 import org.eclipse.gemoc.executionframework.ui.views.engine.EngineSelectionDependentViewPart
 import org.eclipse.swt.widgets.Composite
 import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine
+import org.eclipse.swt.layout.GridData
+import org.eclipse.swt.widgets.Label
+import org.eclipse.swt.SWT
 
 class StrategySelectionView extends EngineSelectionDependentViewPart {
 	
+	public static val ID = "org.eclipse.gemoc.executionframework.engine.io.views.StrategySelectionView"
+	
 	override createPartControl(Composite parent) {
-		throw new UnsupportedOperationException("TODO: auto-generated method stub")
+		val gd = new GridData(GridData.FILL_HORIZONTAL)
+		parent.setLayoutData(gd)
+		val inputLabel = new Label(parent, SWT.NONE)
+		inputLabel.setText("Test")
+		
+//		throw new UnsupportedOperationException("TODO: auto-generated method stub")
 	}
 	
 	override setFocus() {
-		throw new UnsupportedOperationException("TODO: auto-generated method stub")
+//		throw new UnsupportedOperationException("TODO: auto-generated method stub")
 	}
 	
 	override engineSelectionChanged(IExecutionEngine<?> engine) {
-		throw new UnsupportedOperationException("TODO: auto-generated method stub")
+//		throw new UnsupportedOperationException("TODO: auto-generated method stub")
 	}
 	
 }

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/strategy_selector/StrategySelectionView.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/strategy_selector/StrategySelectionView.xtend
@@ -1,0 +1,21 @@
+package uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin.engine.ui.strategy_selector
+
+import org.eclipse.gemoc.executionframework.ui.views.engine.EngineSelectionDependentViewPart
+import org.eclipse.swt.widgets.Composite
+import org.eclipse.gemoc.xdsmlframework.api.core.IExecutionEngine
+
+class StrategySelectionView extends EngineSelectionDependentViewPart {
+	
+	override createPartControl(Composite parent) {
+		throw new UnsupportedOperationException("TODO: auto-generated method stub")
+	}
+	
+	override setFocus() {
+		throw new UnsupportedOperationException("TODO: auto-generated method stub")
+	}
+	
+	override engineSelectionChanged(IExecutionEngine<?> engine) {
+		throw new UnsupportedOperationException("TODO: auto-generated method stub")
+	}
+	
+}

--- a/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/strategy_selector/StrategySelectionView.xtend
+++ b/uk.ac.kcl.inf.modelling.xdsml.gemoc_henshin/src/uk/ac/kcl/inf/modelling/xdsml/gemoc_henshin/engine/ui/strategy_selector/StrategySelectionView.xtend
@@ -156,7 +156,9 @@ class StrategySelectionView extends EngineSelectionDependentViewPart {
 			val checkbox = createCheckButton(parentGroup, sd.humanReadableLabel)
 			checkbox.selection = strategySelections.get(sd)
 
-			val uiControl = sd.getUIControl(parentGroup, configContext)
+			val uiControl = sd.getUIControl(parentGroup, configContext, [
+				sd.updateEngineStrategyDetails()
+			])
 			components.put(sd, new Pair(checkbox, uiControl))
 
 			checkbox.addSelectionListener(new SelectionListener() {
@@ -259,6 +261,15 @@ class StrategySelectionView extends EngineSelectionDependentViewPart {
 					}
 				}
 			}
+		}
+	}
+	
+	protected def updateEngineStrategyDetails(StrategyDefinition sd) {
+		val isSelected = strategySelections.get(sd)
+		
+		if (isSelected) {
+			// No point updating the detailed strategy config otherwise...
+			sd.updateEngineStrategySelection(isSelected, components.get(sd).value)		
 		}
 	}
 }


### PR DESCRIPTION
Fixes #27 for the Henshin engine specifically, only requiring it to be refactored up into the generic engine later.

Todos:

- [x] Create a view
- [x] Add view ID to `HenshinConcurrentEngineLauncher.getAdditionalViewsIDs` so it is started when the engine starts
- [x] Ensure view updates list of strategies held by engine
- [x] Refactor to minimise code duplication between launch config tab and view
